### PR TITLE
Fix target rel on Left Header anchor

### DIFF
--- a/src/modules/ui/components/left_panel/header.js
+++ b/src/modules/ui/components/left_panel/header.js
@@ -50,7 +50,7 @@ const linkStyle = {
 const Header = ({ openShortcutsHelp, name, url }) => (
   <div style={wrapperStyle}>
     <button style={shortcutIconStyle} onClick={openShortcutsHelp}>⌘</button>
-    <a style={linkStyle} href={url} target="_blank">
+    <a style={linkStyle} href={url} target="_blank" rel="noopener noreferrer">
       <h3 style={headingStyle}>{name}</h3>
     </a>
   </div>


### PR DESCRIPTION
Often a developer might have the docs opened from the Header anchor. If they were to pause script execution in Storybook, then the tab with the docs would also be paused.

Fixing the rel on the anchor gets rid of the shared tab context.

See more info at:
https://mathiasbynens.github.io/rel-noopener/

_Note that this unresponsive-docs-tab thing actually happened a handful of times in my office of ~5 developers_ 😂 